### PR TITLE
fix: cap mcp dependency to <2 to unblock CI (GH#519)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
     "Typing :: Typed"
 ]
 dependencies = [
-    "mcp>=1.27.0",
+    "mcp>=1.27.0,<2",  # GH#519: mcp 2.x renamed camelCase kwargs to snake_case (breaking)
     "click>=8.1.0",
     "pydantic>=2.12.0",
     "python-dotenv>=1.2.2",

--- a/tests/unit/test_gh519_mcp_dependency_cap.py
+++ b/tests/unit/test_gh519_mcp_dependency_cap.py
@@ -1,0 +1,67 @@
+"""Tests for GitHub issue #519: unpinned `mcp` dependency breaks CI.
+
+`pyproject.toml` declared the `mcp` SDK dependency with no upper bound
+(`mcp>=1.27.0`). CI installs fresh via `pip install -e ".[dev]"` (no
+lockfile), so it resolves whatever satisfies that constraint from PyPI at
+install time. mcp 2.x is a breaking release (camelCase kwargs renamed to
+snake_case, `Server` generic arity changed, `ReadResourceContents` moved),
+so an unbounded `mcp>=1.27.0` silently drifts CI onto an incompatible major
+version the moment mcp 2.x is published -- exactly what happened: CI
+resolved mcp 2.2.0 and `mypy src` failed with 17 errors across 4 files.
+
+This is NOT reproducible by checking the *installed* mcp version: a
+contributor's local `.venv` (synced via `uv sync` against `uv.lock`, which
+pins mcp==1.27.0) stays green while CI silently drifts red, since `pip
+install -e ".[dev]"` in CI does not consult `uv.lock` at all. The only
+locally-verifiable regression test is against the *declared constraint*
+in pyproject.toml itself -- that is the actual root cause and the only
+artifact that is identical between a contributor's checkout and CI.
+
+Tests verify:
+- The `mcp` runtime dependency specifier in pyproject.toml declares an
+  explicit upper bound excluding the breaking 2.x major series.
+"""
+
+import re
+import tomllib
+from pathlib import Path
+
+PYPROJECT_PATH = Path(__file__).resolve().parents[2] / "pyproject.toml"
+
+
+def _mcp_dependency_specifier() -> str:
+    """Return the raw `mcp` dependency specifier string from [project.dependencies]."""
+    data = tomllib.loads(PYPROJECT_PATH.read_text())
+    dependencies = data["project"]["dependencies"]
+    mcp_specifiers = [dep for dep in dependencies if re.match(r"^mcp\s*(>=|==|~=|<)", dep)]
+    assert len(mcp_specifiers) == 1, (
+        f"Expected exactly one 'mcp' runtime dependency declaration in "
+        f"[project.dependencies], found {len(mcp_specifiers)}: {mcp_specifiers}"
+    )
+    return mcp_specifiers[0]
+
+
+class TestMcpDependencyUpperBound:
+    """GH#519: the mcp dependency must not float across a breaking major version."""
+
+    def test_mcp_dependency_has_upper_bound_excluding_v2(self):
+        """The `mcp` specifier in [project.dependencies] must cap below 2.0.
+
+        mcp 2.x renamed camelCase kwargs to snake_case and changed the
+        `Server` generic arity (see GH#519), breaking `mypy src` on CI
+        the moment an unbounded `mcp>=1.27.0` resolves to 2.2.0+. This
+        test pins the constraint itself, since that is the artifact CI's
+        `pip install -e ".[dev]"` actually consults -- unlike a locally
+        installed mcp version, which can stay at 1.27.0 (via uv.lock)
+        even while the unbounded declaration silently breaks CI.
+        """
+        specifier = _mcp_dependency_specifier()
+
+        assert "<2" in specifier, (
+            f"mcp dependency specifier {specifier!r} has no upper bound excluding "
+            f"the breaking mcp 2.x major release. GH#519: CI's `pip install -e "
+            f"\".[dev]\"` resolved mcp 2.2.0 against an unbounded 'mcp>=1.27.0' "
+            f"and `mypy src` failed with 17 errors (camelCase->snake_case kwarg "
+            f"renames, Server generic arity change, ReadResourceContents move). "
+            f"Expected a specifier containing '<2', e.g. 'mcp>=1.27.0,<2'."
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -670,7 +670,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28.0" },
     { name = "httpx", marker = "extra == 'http'", specifier = ">=0.28.0" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.122.0" },
-    { name = "mcp", specifier = ">=1.27.0" },
+    { name = "mcp", specifier = ">=1.27.0,<2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.14.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "pydantic", specifier = ">=2.12.0" },


### PR DESCRIPTION
## Summary
- `pyproject.toml` declared `mcp>=1.27.0` with no upper bound; CI installs fresh via `pip install -e ".[dev]"` (no lockfile consulted), so it resolved the latest mcp on PyPI (2.2.0) at install time, breaking `mypy src` with 17 errors (camelCase→snake_case kwarg renames, `Server` generic arity change, `ReadResourceContents` moved) — see #519.
- Caps the runtime dependency to `mcp>=1.27.0,<2`. The bare `"mcp"` string at pyproject.toml:16 is a PyPI keyword (search metadata), not a dependency declaration — verified it does not appear in `[project.dependencies]` and does not participate in resolution, so it needs no change.
- Adds `tests/unit/test_gh519_mcp_dependency_cap.py`, asserting the `mcp` specifier in `[project.dependencies]` carries an explicit upper bound. This tests the pyproject constraint itself (not the installed mcp version), because a local `.venv` synced via `uv.lock` (which pins `mcp==1.27.0`) stays green under `mypy` even while the unbounded declaration silently breaks CI — the constraint is the only artifact CI and a local checkout actually share.
- `uv.lock` re-synced to reflect the new constraint (no other dependency changes).

Explicitly out of scope (own follow-up issues): migrating `base_tool.py` / `http_transport.py` / `grammar_resources.py` / `server.py` to the mcp 2.x API, adding a scheduled CI run or `--frozen`/lockfile-based install for the CI matrix to catch future drift earlier.

## Test plan
- [x] RED: `pytest tests/unit/test_gh519_mcp_dependency_cap.py` fails before the fix (`assert '<2' in 'mcp>=1.27.0'`)
- [x] GREEN: same test passes after the `pyproject.toml` cap
- [x] `ruff check src tests` — All checks passed!
- [x] `black --check src tests` — 223 files would be left unchanged
- [x] `mypy src` — Success: no issues found in 58 source files (note: local `.venv` already has mcp 1.27.0 via `uv.lock`, so this does not itself prove the CI fix — see reasoning above)
- [x] `pytest -q` — 3573 passed, 21 skipped, 3 xfailed, 0 failed (includes the 3 known `test_agent_definition_schema.py` GH#461-family cases, which SKIP rather than fail in a fresh worktree since `.hestai-sys/library/agents/` doesn't exist there)

Fixes #519 (cap only, per issue's own scope split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the `mcp` runtime dependency to `>=1.27.0,<2` in `pyproject.toml`. CI installs fresh with no lockfile, so it was resolving mcp 2.2.0, which broke `mypy src` with 17 errors from renamed kwargs, a changed `Server` generic arity, and the moved `ReadResourceContents` type.

- Adds a regression test that asserts the `mcp` specifier in `[project.dependencies]` declares an explicit upper bound.
- Re-syncs `uv.lock` to match the new constraint.
- Migration to the mcp 2.x API is out of scope; this only restores CI compatibility.

<sup>Written for commit 1a8a419180e39e3321325d778be42ea81fbc811f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/octave-mcp/pull/521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

